### PR TITLE
Remove hardcoded images to support routePrefix

### DIFF
--- a/D35E.css
+++ b/D35E.css
@@ -799,7 +799,7 @@
   position: relative;
 }
 .D35E.sheet.actor .level-class-image.active {
-  background-image: url(/systems/D35E/icons/actions/upgrade.svg);
+  background-image: url("icons/actions/upgrade.svg");
 }
 .D35E.sheet.actor .level-class-image span.level {
   width: 20px;
@@ -832,7 +832,7 @@
   left: 0;
   border-top-left-radius: 3px;
   text-align: center;
-  background-image: url(/systems/D35E/icons/actions/orb-direction.svg);
+  background-image: url("icons/actions/orb-direction.svg");
   background-size: 14px;
   background-position: center;
   background-repeat: no-repeat;
@@ -853,7 +853,7 @@
   right: 0;
   border-top-right-radius: 3px;
   text-align: center;
-  background-image: url(/systems/D35E/icons/actions/growth.svg);
+  background-image: url("icons/actions/growth.svg");
   background-size: 14px;
   background-position: center;
   background-repeat: no-repeat;
@@ -1875,11 +1875,11 @@
 }
 .D35E.sheet.actor .inventory-list .item .item-name:hover .item-image:not(.non-rollable),
 .D35E.sheet.actor .inventory-list .item .item-name-ne:hover .item-image:not(.non-rollable) {
-  background-image: url("/icons/svg/d20-grey.svg") !important;
+  background-image: url("../../icons/svg/d20-grey.svg") !important;
 }
 .D35E.sheet.actor .inventory-list .item .item-name .item-image:hover:not(.non-rollable),
 .D35E.sheet.actor .inventory-list .item .item-name-ne .item-image:hover:not(.non-rollable) {
-  background-image: url("/icons/svg/d20-black.svg") !important;
+  background-image: url("../../icons/svg/d20-black.svg") !important;
 }
 .D35E.sheet.actor .inventory-list .item .class-level-box {
   opacity: 0.7;
@@ -2782,10 +2782,10 @@
   margin: 0;
 }
 .D35E.sheet.item .inventory-list .item .item-name:hover .item-image:not(.non-rollable) {
-  background-image: url("/icons/svg/d20-grey.svg") !important;
+  background-image: url("../../icons/svg/d20-grey.svg") !important;
 }
 .D35E.sheet.item .inventory-list .item .item-name .item-image:hover:not(.non-rollable) {
-  background-image: url("/icons/svg/d20-black.svg") !important;
+  background-image: url("../../icons/svg/d20-black.svg") !important;
 }
 .D35E.sheet.item .inventory-list .item input[type="checkbox"] {
   height: 12px;
@@ -3515,7 +3515,7 @@
   height: 22px;
 }
 .D35E.sheet.actor.character .sheet-header .race-container .race.rollable:hover {
-  background-image: url("/icons/svg/d20-black.svg") !important;
+  background-image: url("../../icons/svg/d20-black.svg") !important;
 }
 .D35E.sheet.actor.character .sheet-header .summary li:nth-last-child(1),
 .D35E.sheet.actor.character .sheet-header .summary li:nth-last-child(2) {
@@ -3596,7 +3596,7 @@
   height: 22px;
 }
 .D35E.sheet.actor.npc .race-container .race .rollable:hover {
-  background-image: url("/icons/svg/d20-black.svg") !important;
+  background-image: url("../../icons/svg/d20-black.svg") !important;
 }
 .D35E.sheet.actor.npc .master-block {
   border-right: 2px groove #eeede0;
@@ -3811,8 +3811,8 @@ input[type=range]:disabled {
 }
 .welcome-screen.window-app {
   border: 8px solid #55493B;
-  border-image: url(/systems/D35E/icons/ui/dialog-frame.png) 30 round;
-  background: url(/systems/D35E/icons/ui/sidebar-bg.png);
+  border-image: url("icons/ui/dialog-frame.png") 30 round;
+  background: url("icons/ui/sidebar-bg.png");
   border-radius: 0;
 }
 .welcome-screen .window-content {
@@ -3827,7 +3827,7 @@ input[type=range]:disabled {
   z-index: 10;
 }
 .rolled-attack {
-  background: url(/systems/D35E/icons/damage-type/badges/gladius.svg) no-repeat !important;
+  background: url("icons/damage-type/badges/gladius.svg") no-repeat !important;
   border: none !important;
   height: 60px !important;
   line-height: 60px !important;
@@ -3837,7 +3837,7 @@ input[type=range]:disabled {
   font-size: 44px!important;
 }
 .rolled-defense {
-  background: url(/systems/D35E/icons/damage-type/badges/shield.svg) no-repeat !important;
+  background: url("icons/damage-type/badges/shield.svg") no-repeat !important;
   border: none !important;
   height: 60px !important;
   line-height: 60px !important;
@@ -3847,7 +3847,7 @@ input[type=range]:disabled {
   font-size: 44px!important;
 }
 .rolled-fortify-value {
-  background: url(/systems/D35E/icons/damage-type/badges/chest-armor.svg) no-repeat !important;
+  background: url("icons/damage-type/badges/chest-armor.svg") no-repeat !important;
   border: none !important;
   height: 50px !important;
   line-height: 50px !important;
@@ -3857,7 +3857,7 @@ input[type=range]:disabled {
   font-size: 34px!important;
 }
 .rolled-roll {
-  background: url(/systems/D35E/icons/damage-type/badges/rolling-dices.svg) no-repeat !important;
+  background: url("icons/damage-type/badges/rolling-dices.svg") no-repeat !important;
   border: none !important;
   height: 50px !important;
   line-height: 50px !important;
@@ -3867,7 +3867,7 @@ input[type=range]:disabled {
   font-size: 34px!important;
 }
 .rolled-versus {
-  background: url(/systems/D35E/icons/damage-type/badges/shield-impact.svg) no-repeat !important;
+  background: url("icons/damage-type/badges/shield-impact.svg") no-repeat !important;
   border: none !important;
   height: 50px !important;
   line-height: 50px !important;
@@ -3926,7 +3926,7 @@ span.bold {
   position: relative;
 }
 .portrait-bar .portrait .barbox {
-  background-image: url(/systems/D35E/icons/ui/portrait-bar.png);
+  background-image: url("icons/ui/portrait-bar.png");
   background-size: cover;
   width: 240px;
   height: 26px;
@@ -3943,7 +3943,7 @@ span.bold {
   line-height: 22px;
 }
 .portrait-bar .portrait .barbox .damagebar {
-  background-image: url(/systems/D35E/icons/ui/hp-frame.png);
+  background-image: url("icons/ui/hp-frame.png");
   background-size: cover;
   background-position: right;
   position: absolute;
@@ -3961,7 +3961,7 @@ span.bold {
   z-index: -3;
 }
 .portrait-bar .portrait .barbox .damage {
-  background-image: url(/systems/D35E/icons/ui/hp-bar.png);
+  background-image: url("icons/ui/hp-bar.png");
   background-size: cover;
   background-position: right;
   position: absolute;
@@ -4007,7 +4007,7 @@ span.bold {
 .portrait-bar .portrait .overlay {
   width: 100px;
   height: 100px;
-  background-image: url(/systems/D35E/icons/ui/Hero_icon_frame.png);
+  background-image: url("icons/ui/Hero_icon_frame.png");
   background-size: cover;
   position: absolute;
   top: 0px;
@@ -4029,7 +4029,7 @@ span.bold {
   height: 16px;
   width: 16px;
   margin: 0;
-  background-image: url(/systems/D35E/icons/ui/frame-sq-small.png);
+  background-image: url("icons/ui/frame-sq-small.png");
   background-size: cover;
 }
 .portrait-bar .portrait .buffbox.narrow {
@@ -4301,7 +4301,7 @@ tr.introjs-showElement > th {
   flex: 0;
   width: 50px;
   height: 50px;
-  background-image: url(/systems/D35E/icons/ui/onboarding-hero.png);
+  background-image: url("icons/ui/onboarding-hero.png");
   background-size: cover;
   position: absolute;
   left: -5px;
@@ -4327,7 +4327,7 @@ tr.introjs-showElement > th {
   white-space: nowrap;
   cursor: pointer;
   outline: none;
-  background: url(/systems/D35E/icons/ui/long-button.png);
+  background: url("icons/ui/long-button.png");
   background-size: 100% 100%;
   border: none;
   color: white;
@@ -4373,7 +4373,7 @@ tr.introjs-showElement > th {
 .introjs-disabled,
 .introjs-disabled:hover,
 .introjs-disabled:focus {
-  background: url(/systems/D35E/icons/ui/long-button.png);
+  background: url("icons/ui/long-button.png");
   background-size: 100% 100%;
   border: none;
   color: white;
@@ -4794,7 +4794,7 @@ tr.introjs-showElement > th {
 }
 .d35ecustom .encounter-roller .entity-link {
   border: none;
-  background: url(/systems/D35E/icons/ui/parchment-2.png) repeat;
+  background: url("icons/ui/parchment-2.png") repeat;
   color: rgba(0, 0, 0, 0.7);
   padding: 8px;
   margin-bottom: 4px;
@@ -4844,7 +4844,7 @@ tr.introjs-showElement > th {
   margin: 2px;
   color: white;
   background: none !important;
-  border-image: url(/systems/D35E/icons/ui/toggle-off.png);
+  border-image: url("icons/ui/toggle-off.png");
   border-image-slice: 20 20 fill;
   border-image-width: 170px;
   cursor: pointer;
@@ -4863,7 +4863,7 @@ tr.introjs-showElement > th {
   margin: 2px;
   color: white;
   background: none !important;
-  border-image: url(/systems/D35E/icons/ui/toggle-on.png);
+  border-image: url("icons/ui/toggle-on.png");
   border-image-slice: 20 20 fill;
   border-image-width: 170px;
   cursor: pointer;
@@ -4872,8 +4872,8 @@ tr.introjs-showElement > th {
 }
 .d35ecustom .dr-setting.window-app {
   border: 8px solid #55493B;
-  border-image: url(/systems/D35E/icons/ui/dialog-frame.png) 30 round;
-  background: url(/systems/D35E/icons/ui/sidebar-bg.png);
+  border-image: url("icons/ui/dialog-frame.png") 30 round;
+  background: url("icons/ui/sidebar-bg.png");
   border-radius: 0;
 }
 .d35ecustom .dr-setting.window-app .window-content {
@@ -4926,8 +4926,8 @@ tr.introjs-showElement > th {
 }
 .d35ecustom .compendium-browser-window.window-app {
   border: 8px solid #55493B;
-  border-image: url(/systems/D35E/icons/ui/dialog-frame.png) 30 round;
-  background: url(/systems/D35E/icons/ui/sidebar-bg.png);
+  border-image: url("icons/ui/dialog-frame.png") 30 round;
+  background: url("icons/ui/sidebar-bg.png");
   border-radius: 0;
 }
 .d35ecustom .compendium-browser-window.window-app .window-content {
@@ -4962,7 +4962,7 @@ tr.introjs-showElement > th {
   color: white;
 }
 .d35ecustom #chat-log .chat-message {
-  background: url(/systems/D35E/icons/ui/parchment-tile.png) repeat;
+  background: url("icons/ui/parchment-tile.png") repeat;
   background-size: 288px;
   background-position-y: 40px;
   border: none;
@@ -4978,14 +4978,14 @@ tr.introjs-showElement > th {
   border-right: 1px solid rgba(0, 0, 0, 0.3);
 }
 .d35ecustom #chat-log .chat-message.whisper {
-  background-image: linear-gradient(black, black), url(/systems/D35E/icons/ui/parchment-tile.png);
+  background-image: linear-gradient(black, black), url("icons/ui/parchment-tile.png");
   /* background-size: cover; */
   background-blend-mode: saturation;
 }
 .d35ecustom .window-app.dialog {
   border: 8px solid #55493B;
-  border-image: url(/systems/D35E/icons/ui/dialog-frame.png) 30 round;
-  background: url(/systems/D35E/icons/ui/sidebar-bg.png);
+  border-image: url("icons/ui/dialog-frame.png") 30 round;
+  background: url("icons/ui/sidebar-bg.png");
   border-radius: 0;
 }
 .d35ecustom .window-app.dialog .window-content {
@@ -5007,7 +5007,7 @@ tr.introjs-showElement > th {
   flex: 0 0 522px;
 }
 .d35ecustom #hotbar .macro {
-  background: url(/systems/D35E/icons/ui/skill-frame.png);
+  background: url("icons/ui/skill-frame.png");
   background-size: cover;
   padding: 2px;
   border: none;
@@ -5027,14 +5027,14 @@ tr.introjs-showElement > th {
   position: absolute;
 }
 .d35ecustom #hotbar #hotbar-page-controls {
-  background: url(/systems/D35E/icons/ui/vert-button.png);
+  background: url("icons/ui/vert-button.png");
   background-size: contain;
   border: none;
   flex: 1;
   padding-top: 1px;
 }
 .d35ecustom #hotbar #hotbar-directory-controls {
-  background: url(/systems/D35E/icons/ui/vert-button.png);
+  background: url("icons/ui/vert-button.png");
   background-size: contain;
   border: none;
   flex: 0 0 26px;
@@ -5045,7 +5045,7 @@ tr.introjs-showElement > th {
 }
 .d35ecustom .sidebar-tab .directory-list .directory-item.entity.item::after {
   content: '';
-  background: url(/systems/D35E/icons/ui/skill-frame.png);
+  background: url("icons/ui/skill-frame.png");
   background-size: contain;
   width: 48px;
   height: 48px;
@@ -5054,7 +5054,7 @@ tr.introjs-showElement > th {
   top: 0;
 }
 .d35ecustom button:not(.tah-title-button):not(.tox-tbtn) {
-  background: url(/systems/D35E/icons/ui/long-button.png);
+  background: url("icons/ui/long-button.png");
   background-size: 100% 100%;
   border: none;
   color: white;
@@ -5063,13 +5063,13 @@ tr.introjs-showElement > th {
   filter: grayscale(1);
 }
 .d35ecustom .D35E button:not(.tox-tbtn) {
-  background: url(/systems/D35E/icons/ui/long-button.png);
+  background: url("icons/ui/long-button.png");
   background-size: 100% 100%;
   border: none;
   color: white;
 }
 .d35ecustom .dialog .dialog-buttons button {
-  background: url(/systems/D35E/icons/ui/long-button.png);
+  background: url("icons/ui/long-button.png");
   background-size: 100% 100%;
   border: none;
   color: white;
@@ -5078,7 +5078,7 @@ tr.introjs-showElement > th {
   filter: grayscale(1);
 }
 .d35ecustom .D35E.chat-card .card-buttons button {
-  background: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0.2) 50%, rgba(255, 255, 255, 0) 100%), linear-gradient(rgba(255, 255, 255, 0.3) 0%, rgba(255, 255, 255, 0) 10%, rgba(255, 255, 255, 0) 90%, rgba(255, 255, 255, 0.3) 100%), url(/systems/D35E/icons/ui/button-texture.png) repeat !important;
+  background: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0.2) 50%, rgba(255, 255, 255, 0) 100%), linear-gradient(rgba(255, 255, 255, 0.3) 0%, rgba(255, 255, 255, 0) 10%, rgba(255, 255, 255, 0) 90%, rgba(255, 255, 255, 0.3) 100%), url("icons/ui/button-texture.png") repeat !important;
   border: 1px solid rgba(0, 0, 0, 0.7) !important;
   color: rgba(255, 255, 255, 0.9) !important;
   border-radius: 2px !important;
@@ -5090,7 +5090,7 @@ tr.introjs-showElement > th {
   padding: 0;
 }
 .d35ecustom .D35E.chat-card .card-buttons button:hover:not(:disabled) {
-  background: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0.4) 50%, rgba(255, 255, 255, 0) 100%), linear-gradient(rgba(255, 255, 255, 0.3) 0%, rgba(255, 255, 255, 0) 10%, rgba(255, 255, 255, 0) 90%, rgba(255, 255, 255, 0.3) 100%), url(/systems/D35E/icons/ui/button-texture.png) repeat !important;
+  background: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0.4) 50%, rgba(255, 255, 255, 0) 100%), linear-gradient(rgba(255, 255, 255, 0.3) 0%, rgba(255, 255, 255, 0) 10%, rgba(255, 255, 255, 0) 90%, rgba(255, 255, 255, 0.3) 100%), url("icons/ui/button-texture.png") repeat !important;
   text-shadow: none !important;
   box-shadow: none;
 }
@@ -5100,12 +5100,12 @@ tr.introjs-showElement > th {
 }
 .d35ecustom #navigation #nav-toggle {
   border-radius: 0;
-  background: url(/systems/D35E/icons/ui/mini-button.png);
+  background: url("icons/ui/mini-button.png");
   background-size: 100% 100%;
 }
 .d35ecustom #navigation #scene-list .scene {
   border-radius: 0;
-  background: url(/systems/D35E/icons/ui/name-frame.png);
+  background: url("icons/ui/name-frame.png");
   filter: grayscale(0.4);
   background-size: 100% 100%;
   border: 1px solid rgba(0, 0, 0, 0);
@@ -5118,7 +5118,7 @@ tr.introjs-showElement > th {
 .d35ecustom #navigation #scene-list .scene.gm {
   filter: none;
   border-radius: 0;
-  background: url(/systems/D35E/icons/ui/name-frame.png);
+  background: url("icons/ui/name-frame.png");
   background-size: 100% 100%;
   border: 1px solid rgba(0, 0, 0, 0);
 }
@@ -5131,11 +5131,11 @@ tr.introjs-showElement > th {
   border-radius: 0;
   border: none;
   line-height: 27px;
-  background: url(/systems/D35E/icons/ui/sidebar-bg.png);
+  background: url("icons/ui/sidebar-bg.png");
   background-size: 100% 100%;
 }
 .d35ecustom:not(.transparent-sidebar) #sidebar {
-  background: url(/systems/D35E/icons/ui/sidebar-bg.png);
+  background: url("icons/ui/sidebar-bg.png");
   background-size: 100% 100%;
 }
 .d35ecustom #sidebar {
@@ -5147,11 +5147,11 @@ tr.introjs-showElement > th {
   line-height: initial;
 }
 .d35ecustom #sidebar #scenes .scene h3 {
-  background: url(/systems/D35E/icons/ui/frame-2-1-3.png);
+  background: url("icons/ui/frame-2-1-3.png");
   background-size: 100% 100%;
 }
 .d35ecustom #sidebar #compendium li.compendium-pack {
-  background: url(/systems/D35E/icons/ui/frame-2-1-3.png);
+  background: url("icons/ui/frame-2-1-3.png");
   background-size: 100% 100%;
   margin: 0px;
   padding: 5px 15px;
@@ -5161,7 +5161,7 @@ tr.introjs-showElement > th {
   right: 10px;
 }
 .d35ecustom #sidebar header:not(.message-header):not(.folder-header):not(.card-header):not(.part-header) {
-  background: url(/systems/D35E/icons/ui/sidebar-top.png);
+  background: url("icons/ui/sidebar-top.png");
   background-position: bottom;
   background-size: cover;
   border-bottom: none !important;
@@ -5175,7 +5175,7 @@ tr.introjs-showElement > th {
 }
 .d35ecustom #sidebar li.folder::before {
   content: '';
-  background: url(/systems/D35E/icons/ui/icon-folder.png);
+  background: url("icons/ui/icon-folder.png");
   background-size: contain;
   width: 32px;
   height: 32px;
@@ -5185,7 +5185,7 @@ tr.introjs-showElement > th {
 }
 .d35ecustom #sidebar #journal li.journal::before {
   content: '';
-  background: url(/systems/D35E/icons/ui/icon-journal.png);
+  background: url("icons/ui/icon-journal.png");
   background-size: contain;
   width: 32px;
   height: 32px;
@@ -5203,7 +5203,7 @@ tr.introjs-showElement > th {
 }
 .d35ecustom #sidebar #sidebar-tabs .item {
   border-radius: 0;
-  background: url(/systems/D35E/icons/ui/mini-button-border.png);
+  background: url("icons/ui/mini-button-border.png");
   background-size: 100% 100%;
   line-height: 27px;
   border: none;
@@ -5215,7 +5215,7 @@ tr.introjs-showElement > th {
 }
 .d35ecustom #sidebar #sidebar-tabs .collapse {
   border-radius: 0;
-  background: url(/systems/D35E/icons/ui/mini-button-border.png);
+  background: url("icons/ui/mini-button-border.png");
   background-size: 100% 100%;
   line-height: 27px;
   border: none;
@@ -5226,18 +5226,18 @@ tr.introjs-showElement > th {
 }
 .d35ecustom #controls .scene-control {
   border-radius: 0;
-  background: url(/systems/D35E/icons/ui/mini-button.png);
+  background: url("icons/ui/mini-button.png");
   background-size: cover;
   font-size: 20px;
 }
 .d35ecustom #controls .scene-control .control-tool {
-  background: url(/systems/D35E/icons/ui/mini-button.png);
+  background: url("icons/ui/mini-button.png");
   background-size: cover;
   border-radius: 0;
   font-size: 20px;
 }
 .d35ecustom #controls .scene-control .active {
-  background: url(/systems/D35E/icons/ui/mini-button.png);
+  background: url("icons/ui/mini-button.png");
   background-size: cover;
 }
 .d35ecustom ::-webkit-scrollbar-thumb {
@@ -5247,7 +5247,7 @@ tr.introjs-showElement > th {
   border: 1px solid #896f5f;
 }
 .d35ecustom .placeable-hud .control-icon {
-  background: url(/systems/D35E/icons/ui/skill-frame-bg.png);
+  background: url("icons/ui/skill-frame-bg.png");
   background-size: cover;
   border-radius: 0;
   background-color: #191919;
@@ -5257,7 +5257,7 @@ tr.introjs-showElement > th {
 }
 .d35ecustom .sheet-header-profile::after {
   content: '';
-  background: url(/systems/D35E/icons/ui/large-item-frame-empty.png);
+  background: url("icons/ui/large-item-frame-empty.png");
   background-size: contain;
   width: 100px;
   height: 100px;
@@ -5268,7 +5268,7 @@ tr.introjs-showElement > th {
 }
 .d35ecustom .sheet-header-profile.red::after {
   content: '';
-  background: url(/systems/D35E/icons/ui/large-item-frame-red.png);
+  background: url("icons/ui/large-item-frame-red.png");
   background-size: contain;
   width: 100px;
   height: 100px;
@@ -5279,7 +5279,7 @@ tr.introjs-showElement > th {
 }
 .d35ecustom .sheet-header-profile.blue::after {
   content: '';
-  background: url(/systems/D35E/icons/ui/large-item-frame-blue.png);
+  background: url("icons/ui/large-item-frame-blue.png");
   background-size: contain;
   width: 100px;
   height: 100px;
@@ -5290,7 +5290,7 @@ tr.introjs-showElement > th {
 }
 .d35ecustom .sheet-header-profile.purple::after {
   content: '';
-  background: url(/systems/D35E/icons/ui/large-item-frame-purple.png);
+  background: url("icons/ui/large-item-frame-purple.png");
   background-size: contain;
   width: 100px;
   height: 100px;
@@ -5301,29 +5301,29 @@ tr.introjs-showElement > th {
 }
 .d35ecustom .checkmark {
   border: none;
-  background: url(/systems/D35E/icons/ui/checkbox-unchecked.png);
+  background: url("icons/ui/checkbox-unchecked.png");
   background-size: contain;
   cursor: pointer;
 }
 .d35ecustom input ~ .checkmark {
-  background: url(/systems/D35E/icons/ui/checkbox-unchecked.png);
+  background: url("icons/ui/checkbox-unchecked.png");
   background-size: contain;
 }
 .d35ecustom input:checked ~ .checkmark {
-  background: url(/systems/D35E/icons/ui/checkbox-checked.png);
+  background: url("icons/ui/checkbox-checked.png");
   background-size: contain;
 }
 .d35ecustom .checkmark:after {
   border: none;
 }
 .d35ecustom .blue-button {
-  background: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0.2) 50%, rgba(255, 255, 255, 0) 100%), linear-gradient(rgba(255, 255, 255, 0.3) 0%, rgba(255, 255, 255, 0) 10%, rgba(255, 255, 255, 0) 90%, rgba(255, 255, 255, 0.3) 100%), url(/systems/D35E/icons/ui/button-texture.png) repeat !important;
+  background: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0.2) 50%, rgba(255, 255, 255, 0) 100%), linear-gradient(rgba(255, 255, 255, 0.3) 0%, rgba(255, 255, 255, 0) 10%, rgba(255, 255, 255, 0) 90%, rgba(255, 255, 255, 0.3) 100%), url("icons/ui/button-texture.png") repeat !important;
   border: 1px solid rgba(0, 0, 0, 0.7) !important;
   color: rgba(255, 255, 255, 0.9) !important;
   border-radius: 2px !important;
 }
 .d35ecustom .blue-button:hover {
-  background: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0.4) 50%, rgba(255, 255, 255, 0) 100%), linear-gradient(rgba(255, 255, 255, 0.3) 0%, rgba(255, 255, 255, 0) 10%, rgba(255, 255, 255, 0) 90%, rgba(255, 255, 255, 0.3) 100%), url(/systems/D35E/icons/ui/button-texture.png) repeat !important;
+  background: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0.4) 50%, rgba(255, 255, 255, 0) 100%), linear-gradient(rgba(255, 255, 255, 0.3) 0%, rgba(255, 255, 255, 0) 10%, rgba(255, 255, 255, 0) 90%, rgba(255, 255, 255, 0.3) 100%), url("icons/ui/button-texture.png") repeat !important;
   text-shadow: none !important;
 }
 .d35ecustom .blue-button:disabled {
@@ -5336,11 +5336,11 @@ tr.introjs-showElement > th {
 }
 .d35ecustom .sheet {
   border: 6px solid #55493B;
-  border-image: url(/systems/D35E/icons/ui/dialog-frame.png) 20 round;
+  border-image: url("icons/ui/dialog-frame.png") 20 round;
 }
 .d35ecustom .sheet.window-app .window-header {
   color: white;
-  background: url(/systems/D35E/icons/ui/background-header.png) repeat;
+  background: url("icons/ui/background-header.png") repeat;
   border-bottom: 2px solid rgba(255, 255, 255, 0.2);
   line-height: 30px;
 }
@@ -5354,7 +5354,7 @@ tr.introjs-showElement > th {
   border-top: 2px solid #75514b !important;
 }
 .d35ecustom .sheet.actor.character .window-content {
-  background: url(/systems/D35E/icons/ui/background-window.png) repeat;
+  background: url("icons/ui/background-window.png") repeat;
 }
 .d35ecustom .sheet.actor.character .header-details h1 {
   padding: 0;
@@ -5364,7 +5364,7 @@ tr.introjs-showElement > th {
   margin: 8px 3px;
 }
 .d35ecustom .sheet.actor.npc .window-content {
-  background: url(/systems/D35E/icons/ui/background-window.png) repeat;
+  background: url("icons/ui/background-window.png") repeat;
 }
 .d35ecustom .sheet.actor .level-up-boxes {
   flex: 110px 0;
@@ -5441,7 +5441,7 @@ tr.introjs-showElement > th {
   /* margin: 0 0 4px; */
   border-top-left-radius: 2px;
   border-top-right-radius: 2px;
-  background: linear-gradient(rgba(255, 255, 255, 0.3) 100%, rgba(255, 255, 255, 0.3) 100%), url(/systems/D35E/icons/ui/parchment-2.png) repeat;
+  background: linear-gradient(rgba(255, 255, 255, 0.3) 100%, rgba(255, 255, 255, 0.3) 100%), url("icons/ui/parchment-2.png") repeat;
   color: rgba(0, 0, 0, 0.8);
   border-bottom: rgba(0, 0, 0, 0.2);
 }
@@ -5457,7 +5457,7 @@ tr.introjs-showElement > th {
   margin: 2px -4px;
 }
 .d35ecustom .sheet.actor .primary-body {
-  background: url(/systems/D35E/icons/ui/parchment-2.png) repeat;
+  background: url("icons/ui/parchment-2.png") repeat;
   border-bottom-left-radius: 2px;
   border-bottom-right-radius: 2px;
 }
@@ -5565,7 +5565,7 @@ tr.introjs-showElement > th {
   border-bottom: none;
   margin: 0 0 4px;
   padding: 4px;
-  background: linear-gradient(rgba(255, 255, 255, 0.3) 100%, rgba(255, 255, 255, 0.3) 100%), url(/systems/D35E/icons/ui/parchment-2.png) repeat;
+  background: linear-gradient(rgba(255, 255, 255, 0.3) 100%, rgba(255, 255, 255, 0.3) 100%), url("icons/ui/parchment-2.png") repeat;
   border-radius: 2px;
 }
 .d35ecustom .sheet .sheet-header .header-details {
@@ -5624,15 +5624,15 @@ tr.introjs-showElement > th {
 }
 .d35ecustom .sheet.item .window-header {
   color: white;
-  background: url(/systems/D35E/icons/ui/background-header.png) repeat;
+  background: url("icons/ui/background-header.png") repeat;
   border-bottom: 2px solid rgba(255, 255, 255, 0.2);
   line-height: 24px;
 }
 .d35ecustom .sheet.item section.window-content {
-  background: url(/systems/D35E/icons/ui/background-window.png) repeat;
+  background: url("icons/ui/background-window.png") repeat;
 }
 .d35ecustom .sheet.item section.sheet-content {
-  background: url(/systems/D35E/icons/ui/parchment-2.png) repeat;
+  background: url("icons/ui/parchment-2.png") repeat;
   margin: 0px;
   border-radius: 2px;
   min-height: 420px;
@@ -5646,14 +5646,14 @@ tr.introjs-showElement > th {
 .d35ecustom .sheet.item .original-weapon-box {
   margin-bottom: 4px;
   border-radius: 2px;
-  background: url(/systems/D35E/icons/ui/parchment-2.png) repeat;
+  background: url("icons/ui/parchment-2.png") repeat;
 }
 .d35ecustom .sheet.item .original-weapon-box .sheet-header-small img {
   border: none;
 }
 .d35ecustom .sheet.item .original-weapon-box .sheet-header-small::after {
   content: '';
-  background: url(/systems/D35E/icons/ui/item-frame.png);
+  background: url("icons/ui/item-frame.png");
   background-size: contain;
   width: 40px;
   height: 40px;
@@ -5666,7 +5666,7 @@ tr.introjs-showElement > th {
   overflow: auto;
 }
 .d35ecustom .sheet.item header {
-  background: linear-gradient(rgba(255, 255, 255, 0.3) 100%, rgba(255, 255, 255, 0.3) 100%), url(/systems/D35E/icons/ui/parchment-2.png) repeat;
+  background: linear-gradient(rgba(255, 255, 255, 0.3) 100%, rgba(255, 255, 255, 0.3) 100%), url("icons/ui/parchment-2.png") repeat;
   padding: 4px;
   border-radius: 2px;
 }
@@ -5678,7 +5678,7 @@ tr.introjs-showElement > th {
   margin: 8px 0;
 }
 .d35ecustom .level-up-data .window-header {
-  background: url(/systems/D35E/icons/background/paper.png), url(ui/parchment.jpg) repeat;
+  background: url("icons/background/paper.png"), url("ui/parchment.jpg") repeat;
   background-size: auto;
   background-position-y: -70px;
   background-repeat: no-repeat, repeat;
@@ -5686,7 +5686,7 @@ tr.introjs-showElement > th {
   border-bottom: 1px solid rgba(0, 0, 0, 0.2);
 }
 .d35ecustom .level-up-data .header {
-  background: url(/systems/D35E/icons/background/paper.png), url(ui/parchment.jpg) repeat;
+  background: url("icons/background/paper.png"), url("ui/parchment.jpg") repeat;
   background-repeat: no-repeat, repeat;
   background-position-y: bottom;
 }
@@ -5731,10 +5731,10 @@ tr.introjs-showElement > th {
   text-shadow: none !important;
 }
 .d35ecustom .scrolling-header {
-  background: url(/systems/D35E/icons/ui/parchment-2.png) repeat !important;
+  background: url("icons/ui/parchment-2.png") repeat !important;
 }
 .d35ecustom .item-add-overlay .item-add-list {
-  background: url(/systems/D35E/icons/ui/parchment-2.png) repeat !important;
+  background: url("icons/ui/parchment-2.png") repeat !important;
 }
 .d35ecustom .item-add-overlay .item-add-list .item-search-input {
   padding: 10px 10px 10px 35px;
@@ -5748,14 +5748,14 @@ tr.introjs-showElement > th {
   margin: 4px 0;
 }
 .d35ecustom .item-add-overlay .item-add-list .item-add-close-box {
-  background: url(/systems/D35E/icons/ui/parchment-2.png) repeat !important;
+  background: url("icons/ui/parchment-2.png") repeat !important;
   color: #2C606D;
 }
 .d35ecustom .npc.monster {
   padding: 0;
   border-radius: 2px;
   border: none !important;
-  background: url(/systems/D35E/icons/ui/parchment-2.png) repeat;
+  background: url("icons/ui/parchment-2.png") repeat;
 }
 .d35ecustom .npc.monster input[type="text"],
 .d35ecustom .npc.monster textarea {
@@ -5822,7 +5822,7 @@ tr.introjs-showElement > th {
 .d35ecustom .compendium-browser header {
   border: 8px solid red;
   /* border-right: none; */
-  border-image: url(/systems/D35E/icons/ui/side-panel.png);
+  border-image: url("icons/ui/side-panel.png");
   padding-right: 0;
   background-size: 100% 100%;
   /* border: 8px solid #55493B; */
@@ -5841,7 +5841,7 @@ tr.introjs-showElement > th {
 .d35ecustom .compendium-browser .directory-container .directory-list .directory-item {
   align-items: center;
   border-bottom: none;
-  background-image: url(/systems/D35E/icons/ui/basic-bar.png);
+  background-image: url("icons/ui/basic-bar.png");
   background-size: 100% 100%;
 }
 .d35ecustom .compendium-browser .directory-container .directory-list .directory-item img {
@@ -5849,7 +5849,7 @@ tr.introjs-showElement > th {
 }
 .d35ecustom #token-action-hud button {
   border-radius: 0;
-  background: url(/systems/D35E/icons/ui/name-frame.png);
+  background: url("icons/ui/name-frame.png");
   background-size: 100% 100%;
   border: 1px solid rgba(0, 0, 0, 0);
   padding: 0 5px;
@@ -5866,7 +5866,7 @@ tr.introjs-showElement > th {
   display: block;
 }
 .onboarding {
-  background: url(/systems/D35E/icons/ui/onboarding.png);
+  background: url("icons/ui/onboarding.png");
   background-size: 100% 100%;
   height: auto !important;
 }
@@ -5888,7 +5888,7 @@ tr.introjs-showElement > th {
   flex: 0;
   width: 150px;
   height: 150px;
-  background-image: url(/systems/D35E/icons/ui/onboarding-hero.png);
+  background-image: url("icons/ui/onboarding-hero.png");
   background-size: cover;
   position: absolute;
   left: -160px;

--- a/less/actors.less
+++ b/less/actors.less
@@ -141,7 +141,7 @@
     border: 1px solid #2f2220;
     position: relative;
     &.active {
-      background-image: url(/systems/D35E/icons/actions/upgrade.svg);
+      background-image: url("icons/actions/upgrade.svg");
     }
 
 
@@ -177,7 +177,7 @@
       left: 0;
       border-top-left-radius: 3px;
       text-align: center;
-      background-image: url(/systems/D35E/icons/actions/orb-direction.svg);
+      background-image: url("icons/actions/orb-direction.svg");
       background-size: 14px;
       background-position: center;
       background-repeat: no-repeat;
@@ -199,7 +199,7 @@
       right: 0;
       border-top-right-radius: 3px;
       text-align: center;
-      background-image: url(/systems/D35E/icons/actions/growth.svg);
+      background-image: url("icons/actions/growth.svg");
       background-size: 14px;
       background-position: center;
       background-repeat: no-repeat;
@@ -1402,11 +1402,11 @@
         }
 
         &:hover .item-image:not(.non-rollable) {
-          background-image: url("/icons/svg/d20-grey.svg") !important;
+          background-image: url("../../icons/svg/d20-grey.svg") !important;
         }
 
         .item-image:hover:not(.non-rollable) {
-          background-image: url("/icons/svg/d20-black.svg") !important;
+          background-image: url("../../icons/svg/d20-black.svg") !important;
         }
       }
 

--- a/less/character.less
+++ b/less/character.less
@@ -73,7 +73,7 @@
         margin-right: 4px;
         height: 22px;
         &.rollable:hover {
-          background-image: url("/icons/svg/d20-black.svg") !important;
+          background-image: url("../../icons/svg/d20-black.svg") !important;
         }
       }
     }

--- a/less/intro.less
+++ b/less/intro.less
@@ -202,7 +202,7 @@ tr.introjs-showElement > th {
   flex: 0;
   width: 50px;
   height: 50px;
-  background-image: url(/systems/D35E/icons/ui/onboarding-hero.png);
+  background-image: url("icons/ui/onboarding-hero.png");
   background-size: cover;
   position: absolute;
   left: -5px;
@@ -230,7 +230,7 @@ tr.introjs-showElement > th {
   white-space: nowrap;
   cursor: pointer;
   outline: none;
-  background: url(/systems/D35E/icons/ui/long-button.png);
+  background: url("icons/ui/long-button.png");
   background-size: 100% 100%;
   border: none;
   color: white;
@@ -293,7 +293,7 @@ tr.introjs-showElement > th {
 }
 
 .introjs-disabled, .introjs-disabled:hover, .introjs-disabled:focus {
-  background: url(/systems/D35E/icons/ui/long-button.png);
+  background: url("icons/ui/long-button.png");
   background-size: 100% 100%;
   border: none;
   color: white;

--- a/less/items.less
+++ b/less/items.less
@@ -538,11 +538,11 @@
         }
 
         &:hover .item-image:not(.non-rollable) {
-          background-image: url("/icons/svg/d20-grey.svg") !important;
+          background-image: url("../../icons/svg/d20-grey.svg") !important;
         }
 
         .item-image:hover:not(.non-rollable) {
-          background-image: url("/icons/svg/d20-black.svg") !important;
+          background-image: url("../../icons/svg/d20-black.svg") !important;
         }
       }
 

--- a/less/misc.less
+++ b/less/misc.less
@@ -136,8 +136,8 @@ input[type=range]:disabled {
 .welcome-screen {
   &.window-app {
     border: 8px solid #55493B;
-    border-image: url(/systems/D35E/icons/ui/dialog-frame.png) 30 round;
-    background: url(/systems/D35E/icons/ui/sidebar-bg.png);
+    border-image: url("icons/ui/dialog-frame.png") 30 round;
+    background: url("icons/ui/sidebar-bg.png");
     border-radius: 0;
   }
   .window-content {
@@ -154,7 +154,7 @@ input[type=range]:disabled {
 }
 
 .rolled-attack {
-  background: url(/systems/D35E/icons/damage-type/badges/gladius.svg) no-repeat !important;
+  background: url("icons/damage-type/badges/gladius.svg") no-repeat !important;
   border: none !important;
   height: 60px !important;
   line-height: 60px !important;
@@ -165,7 +165,7 @@ input[type=range]:disabled {
 }
 
 .rolled-defense {
-  background: url(/systems/D35E/icons/damage-type/badges/shield.svg) no-repeat !important;
+  background: url("icons/damage-type/badges/shield.svg") no-repeat !important;
   border: none !important;
   height: 60px !important;
   line-height: 60px !important;
@@ -176,7 +176,7 @@ input[type=range]:disabled {
 }
 
 .rolled-fortify-value {
-  background: url(/systems/D35E/icons/damage-type/badges/chest-armor.svg) no-repeat !important;
+  background: url("icons/damage-type/badges/chest-armor.svg") no-repeat !important;
   border: none !important;
   height: 50px !important;
   line-height: 50px !important;
@@ -187,7 +187,7 @@ input[type=range]:disabled {
 }
 
 .rolled-roll {
-  background: url(/systems/D35E/icons/damage-type/badges/rolling-dices.svg) no-repeat !important;
+  background: url("icons/damage-type/badges/rolling-dices.svg") no-repeat !important;
   border: none !important;
   height: 50px !important;
   line-height: 50px !important;
@@ -198,7 +198,7 @@ input[type=range]:disabled {
 }
 
 .rolled-versus {
-  background: url(/systems/D35E/icons/damage-type/badges/shield-impact.svg) no-repeat !important;
+  background: url("icons/damage-type/badges/shield-impact.svg") no-repeat !important;
   border: none !important;
   height: 50px !important;
   line-height: 50px !important;

--- a/less/npc.less
+++ b/less/npc.less
@@ -33,7 +33,7 @@
       margin-right: 4px;
       height: 22px;
       .rollable:hover {
-        background-image: url("/icons/svg/d20-black.svg") !important;
+        background-image: url("../../icons/svg/d20-black.svg") !important;
       }
     }
   }

--- a/less/system.less
+++ b/less/system.less
@@ -281,7 +281,7 @@
   .encounter-roller {
     .entity-link {
       border: none;
-      background: url(/systems/D35E/icons/ui/parchment-2.png) repeat;
+      background: url("icons/ui/parchment-2.png") repeat;
       color: rgba(0,0,0,0.7);
       padding: 8px;
       margin-bottom: 4px;
@@ -348,7 +348,7 @@
     margin: 2px;
     color: white;
     background: none !important;
-    border-image: url(/systems/D35E/icons/ui/toggle-off.png);
+    border-image: url("icons/ui/toggle-off.png");
     border-image-slice: 20 20 fill;
     border-image-width: 170px;
     cursor: pointer;
@@ -369,7 +369,7 @@
     margin: 2px;
     color: white;
     background: none !important;
-    border-image: url(/systems/D35E/icons/ui/toggle-on.png);
+    border-image: url("icons/ui/toggle-on.png");
     border-image-slice: 20 20 fill;
     border-image-width: 170px;
     cursor: pointer;
@@ -381,8 +381,8 @@
 
     &.window-app {
       border: 8px solid #55493B;
-      border-image: url(/systems/D35E/icons/ui/dialog-frame.png) 30 round;
-      background: url(/systems/D35E/icons/ui/sidebar-bg.png);
+      border-image: url("icons/ui/dialog-frame.png") 30 round;
+      background: url("icons/ui/sidebar-bg.png");
       border-radius: 0;
       .window-content {
         padding: 0 !important;
@@ -453,8 +453,8 @@
 
     &.window-app {
       border: 8px solid #55493B;
-      border-image: url(/systems/D35E/icons/ui/dialog-frame.png) 30 round;
-      background: url(/systems/D35E/icons/ui/sidebar-bg.png);
+      border-image: url("icons/ui/dialog-frame.png") 30 round;
+      background: url("icons/ui/sidebar-bg.png");
       border-radius: 0;
       .window-content {
         padding: 0 !important;
@@ -496,7 +496,7 @@
     }
   }
   #chat-log .chat-message {
-    background: url(/systems/D35E/icons/ui/parchment-tile.png) repeat;
+    background: url("icons/ui/parchment-tile.png") repeat;
     background-size: 288px;
     background-position-y: 40px;
     border: none;
@@ -514,7 +514,7 @@
     }
 
     &.whisper {
-      background-image: linear-gradient(black, black),url(/systems/D35E/icons/ui/parchment-tile.png);
+      background-image: linear-gradient(black, black),url("icons/ui/parchment-tile.png");
       /* background-size: cover; */
       background-blend-mode: saturation;
     }
@@ -523,8 +523,8 @@
 
   .window-app.dialog {
     border: 8px solid #55493B;
-    border-image: url(/systems/D35E/icons/ui/dialog-frame.png) 30 round;
-    background: url(/systems/D35E/icons/ui/sidebar-bg.png);
+    border-image: url("icons/ui/dialog-frame.png") 30 round;
+    background: url("icons/ui/sidebar-bg.png");
     border-radius: 0;
     .window-content {
       background: none;
@@ -553,7 +553,7 @@
     }
 
     .macro {
-      background: url(/systems/D35E/icons/ui/skill-frame.png);
+      background: url("icons/ui/skill-frame.png");
       background-size: cover;
       padding: 2px;
       border: none;
@@ -577,7 +577,7 @@
     }
 
     #hotbar-page-controls {
-      background: url(/systems/D35E/icons/ui/vert-button.png);
+      background: url("icons/ui/vert-button.png");
       background-size: contain;
       border: none;
       flex: 1;
@@ -586,7 +586,7 @@
     }
 
     #hotbar-directory-controls {
-      background: url(/systems/D35E/icons/ui/vert-button.png);
+      background: url("icons/ui/vert-button.png");
       background-size: contain;
       border: none;
       flex: 0 0 26px;
@@ -604,7 +604,7 @@
         }
         &.entity.item::after{
           content: '';
-          background: url(/systems/D35E/icons/ui/skill-frame.png);
+          background: url("icons/ui/skill-frame.png");
           background-size: contain;
           width: 48px;
           height: 48px;
@@ -619,7 +619,7 @@
 
   button:not(.tah-title-button):not(.tox-tbtn){
 
-    background: url(/systems/D35E/icons/ui/long-button.png);
+    background: url("icons/ui/long-button.png");
     background-size: 100% 100%;
     border: none;
     color: white;
@@ -630,7 +630,7 @@
 
   .D35E button:not(.tox-tbtn)  {
 
-    background: url(/systems/D35E/icons/ui/long-button.png);
+    background: url("icons/ui/long-button.png");
     background-size: 100% 100%;
     border: none;
     color: white;
@@ -638,7 +638,7 @@
   }
 
   .dialog .dialog-buttons button {
-    background: url(/systems/D35E/icons/ui/long-button.png);
+    background: url("icons/ui/long-button.png");
     background-size: 100% 100%;
     border: none;
     color: white;
@@ -650,7 +650,7 @@
 
   .D35E.chat-card .card-buttons button {
 
-    background: linear-gradient(to right, rgba(255, 255, 255, 0.0) 0%, rgba(255, 255, 255, 0.2) 50%, rgba(255, 255, 255, 0.0)100%), linear-gradient(rgba(255, 255, 255, 0.3) 0%, rgba(255, 255, 255, 0.0) 10%, rgba(255, 255, 255, 0.0) 90%, rgba(255, 255, 255, 0.3)100%), url(/systems/D35E/icons/ui/button-texture.png) repeat !important;
+    background: linear-gradient(to right, rgba(255, 255, 255, 0.0) 0%, rgba(255, 255, 255, 0.2) 50%, rgba(255, 255, 255, 0.0)100%), linear-gradient(rgba(255, 255, 255, 0.3) 0%, rgba(255, 255, 255, 0.0) 10%, rgba(255, 255, 255, 0.0) 90%, rgba(255, 255, 255, 0.3)100%), url("icons/ui/button-texture.png") repeat !important;
     border: 1px solid rgba(0,0,0,0.7) !important;
     color: rgba(255,255,255,0.9) !important;
     border-radius: 2px !important;
@@ -658,7 +658,7 @@
     font-size: 19px;
     cursor: pointer;
     &:hover:not(:disabled) {
-      background: linear-gradient(to right, rgba(255, 255, 255, 0.0) 0%, rgba(255, 255, 255, 0.4) 50%, rgba(255, 255, 255, 0.0)100%), linear-gradient(rgba(255, 255, 255, 0.3) 0%, rgba(255, 255, 255, 0.0) 10%, rgba(255, 255, 255, 0.0) 90%, rgba(255, 255, 255, 0.3)100%), url(/systems/D35E/icons/ui/button-texture.png) repeat !important;
+      background: linear-gradient(to right, rgba(255, 255, 255, 0.0) 0%, rgba(255, 255, 255, 0.4) 50%, rgba(255, 255, 255, 0.0)100%), linear-gradient(rgba(255, 255, 255, 0.3) 0%, rgba(255, 255, 255, 0.0) 10%, rgba(255, 255, 255, 0.0) 90%, rgba(255, 255, 255, 0.3)100%), url("icons/ui/button-texture.png") repeat !important;
       text-shadow: none !important;
       box-shadow: none;
     }
@@ -674,14 +674,14 @@
   #navigation {
     #nav-toggle {
       border-radius: 0;
-      background: url(/systems/D35E/icons/ui/mini-button.png);
+      background: url("icons/ui/mini-button.png");
       background-size: 100% 100%;
     }
 
     #scene-list {
       .scene {
         border-radius: 0;
-        background: url(/systems/D35E/icons/ui/name-frame.png);
+        background: url("icons/ui/name-frame.png");
         filter: grayscale(0.4);
         background-size: 100% 100%;
         border: 1px solid rgba(0, 0, 0, 0);
@@ -694,7 +694,7 @@
         &.gm {
           filter: none;
           border-radius: 0;
-          background: url(/systems/D35E/icons/ui/name-frame.png);
+          background: url("icons/ui/name-frame.png");
           background-size: 100% 100%;
           border: 1px solid rgba(0, 0, 0, 0);
 
@@ -713,13 +713,13 @@
     border-radius: 0;
     border: none;
     line-height: 27px;
-    background: url(/systems/D35E/icons/ui/sidebar-bg.png);
+    background: url("icons/ui/sidebar-bg.png");
     background-size: 100% 100%;
   }
 
   &:not(.transparent-sidebar) {
     #sidebar {
-      background: url(/systems/D35E/icons/ui/sidebar-bg.png);
+      background: url("icons/ui/sidebar-bg.png");
       background-size: 100% 100%;
     }
   }
@@ -735,13 +735,13 @@
 
     #scenes .scene {
       h3 {
-        background: url(/systems/D35E/icons/ui/frame-2-1-3.png);
+        background: url("icons/ui/frame-2-1-3.png");
         background-size: 100% 100%;
       }
     }
 
     #compendium li.compendium-pack {
-      background: url(/systems/D35E/icons/ui/frame-2-1-3.png);
+      background: url("icons/ui/frame-2-1-3.png");
       background-size: 100% 100%;
       margin: 0px;
       padding: 5px 15px;
@@ -753,7 +753,7 @@
     }
 
     header:not(.message-header):not(.folder-header):not(.card-header):not(.part-header) {
-      background: url(/systems/D35E/icons/ui/sidebar-top.png);
+      background: url("icons/ui/sidebar-top.png");
       background-position: bottom;
       background-size: cover;
       border-bottom: none !important;
@@ -769,7 +769,7 @@
       }
       &::before{
         content: '';
-        background: url(/systems/D35E/icons/ui/icon-folder.png);
+        background: url("icons/ui/icon-folder.png");
         background-size: contain;
         width: 32px;
         height: 32px;
@@ -782,7 +782,7 @@
     #journal li.journal {
       &::before{
         content: '';
-        background: url(/systems/D35E/icons/ui/icon-journal.png);
+        background: url("icons/ui/icon-journal.png");
         background-size: contain;
         width: 32px;
         height: 32px;
@@ -807,7 +807,7 @@
       .item {
 
         border-radius: 0;
-        background: url(/systems/D35E/icons/ui/mini-button-border.png);
+        background: url("icons/ui/mini-button-border.png");
         background-size: 100% 100%;
         line-height: 27px;
         border: none;
@@ -821,7 +821,7 @@
 
       .collapse {
         border-radius: 0;
-        background: url(/systems/D35E/icons/ui/mini-button-border.png);
+        background: url("icons/ui/mini-button-border.png");
         background-size: 100% 100%;
         line-height: 27px;
         border: none;
@@ -843,19 +843,19 @@
     .scene-control {
 
       border-radius: 0;
-      background: url(/systems/D35E/icons/ui/mini-button.png);
+      background: url("icons/ui/mini-button.png");
       background-size: cover;
       font-size: 20px;
 
       .control-tool {
-        background: url(/systems/D35E/icons/ui/mini-button.png);
+        background: url("icons/ui/mini-button.png");
         background-size: cover;
         border-radius: 0;
         font-size: 20px;
       }
 
       .active {
-        background: url(/systems/D35E/icons/ui/mini-button.png);
+        background: url("icons/ui/mini-button.png");
         background-size: cover;
       }
     }
@@ -869,7 +869,7 @@
   }
 
   .placeable-hud .control-icon {
-    background: url(/systems/D35E/icons/ui/skill-frame-bg.png);
+    background: url("icons/ui/skill-frame-bg.png");
     background-size: cover;
     border-radius: 0;
     background-color: #191919;
@@ -882,7 +882,7 @@
 
     &::after{
       content: '';
-      background: url(/systems/D35E/icons/ui/large-item-frame-empty.png);
+      background: url("icons/ui/large-item-frame-empty.png");
       background-size: contain;
       width: 100px;
       height: 100px;
@@ -896,7 +896,7 @@
     &.red {
       &::after {
         content: '';
-        background: url(/systems/D35E/icons/ui/large-item-frame-red.png);
+        background: url("icons/ui/large-item-frame-red.png");
         background-size: contain;
         width: 100px;
         height: 100px;
@@ -909,7 +909,7 @@
     &.blue {
       &::after {
         content: '';
-        background: url(/systems/D35E/icons/ui/large-item-frame-blue.png);
+        background: url("icons/ui/large-item-frame-blue.png");
         background-size: contain;
         width: 100px;
         height: 100px;
@@ -922,7 +922,7 @@
     &.purple {
       &::after {
         content: '';
-        background: url(/systems/D35E/icons/ui/large-item-frame-purple.png);
+        background: url("icons/ui/large-item-frame-purple.png");
         background-size: contain;
         width: 100px;
         height: 100px;
@@ -938,18 +938,18 @@
 
   .checkmark {
     border: none;
-    background: url(/systems/D35E/icons/ui/checkbox-unchecked.png);
+    background: url("icons/ui/checkbox-unchecked.png");
     background-size: contain;
     cursor: pointer;
   }
 
   input ~ .checkmark {
-    background: url(/systems/D35E/icons/ui/checkbox-unchecked.png);
+    background: url("icons/ui/checkbox-unchecked.png");
     background-size: contain;
   }
   input:checked ~ .checkmark {
 
-    background: url(/systems/D35E/icons/ui/checkbox-checked.png);
+    background: url("icons/ui/checkbox-checked.png");
     background-size: contain;
   }
 
@@ -959,12 +959,12 @@
 
 
   .blue-button {
-    background: linear-gradient(to right, rgba(255, 255, 255, 0.0) 0%, rgba(255, 255, 255, 0.2) 50%, rgba(255, 255, 255, 0.0)100%), linear-gradient(rgba(255, 255, 255, 0.3) 0%, rgba(255, 255, 255, 0.0) 10%, rgba(255, 255, 255, 0.0) 90%, rgba(255, 255, 255, 0.3)100%), url(/systems/D35E/icons/ui/button-texture.png) repeat !important;
+    background: linear-gradient(to right, rgba(255, 255, 255, 0.0) 0%, rgba(255, 255, 255, 0.2) 50%, rgba(255, 255, 255, 0.0)100%), linear-gradient(rgba(255, 255, 255, 0.3) 0%, rgba(255, 255, 255, 0.0) 10%, rgba(255, 255, 255, 0.0) 90%, rgba(255, 255, 255, 0.3)100%), url("icons/ui/button-texture.png") repeat !important;
     border: 1px solid rgba(0,0,0,0.7) !important;
     color: rgba(255,255,255,0.9) !important;
     border-radius: 2px !important;
     &:hover {
-      background: linear-gradient(to right, rgba(255, 255, 255, 0.0) 0%, rgba(255, 255, 255, 0.4) 50%, rgba(255, 255, 255, 0.0)100%), linear-gradient(rgba(255, 255, 255, 0.3) 0%, rgba(255, 255, 255, 0.0) 10%, rgba(255, 255, 255, 0.0) 90%, rgba(255, 255, 255, 0.3)100%), url(/systems/D35E/icons/ui/button-texture.png) repeat !important;
+      background: linear-gradient(to right, rgba(255, 255, 255, 0.0) 0%, rgba(255, 255, 255, 0.4) 50%, rgba(255, 255, 255, 0.0)100%), linear-gradient(rgba(255, 255, 255, 0.3) 0%, rgba(255, 255, 255, 0.0) 10%, rgba(255, 255, 255, 0.0) 90%, rgba(255, 255, 255, 0.3)100%), url("icons/ui/button-texture.png") repeat !important;
       text-shadow: none !important;
     }
     &:disabled {
@@ -980,11 +980,11 @@
 
   .sheet {
     border: 6px solid #55493B;
-    border-image: url(/systems/D35E/icons/ui/dialog-frame.png) 20 round;
+    border-image: url("icons/ui/dialog-frame.png") 20 round;
     &.window-app {
       .window-header {
         color: white;
-        background: url(/systems/D35E/icons/ui/background-header.png) repeat;
+        background: url("icons/ui/background-header.png") repeat;
         border-bottom: 2px solid rgba(255,255,255,0.2);
         line-height: 30px;
       }
@@ -1012,7 +1012,7 @@
       &.character {
         .window-content {
 
-          background: url(/systems/D35E/icons/ui/background-window.png) repeat;
+          background: url("icons/ui/background-window.png") repeat;
         }
 
         .header-details {
@@ -1030,7 +1030,7 @@
       &.npc {
         .window-content {
 
-          background: url(/systems/D35E/icons/ui/background-window.png) repeat;
+          background: url("icons/ui/background-window.png") repeat;
         }
       }
 
@@ -1118,7 +1118,7 @@
         border-top-left-radius: 2px;
         border-top-right-radius: 2px;
 
-        background: linear-gradient( rgba(255,255,255,0.3) 100%, rgba(255,255,255,0.3)100%), url(/systems/D35E/icons/ui/parchment-2.png) repeat;
+        background: linear-gradient( rgba(255,255,255,0.3) 100%, rgba(255,255,255,0.3)100%), url("icons/ui/parchment-2.png") repeat;
         color: rgba(0,0,0,0.8);
         border-bottom: rgba(0,0,0,0.2);
 
@@ -1137,7 +1137,7 @@
 
       .primary-body {
 
-        background: url(/systems/D35E/icons/ui/parchment-2.png) repeat;
+        background: url("icons/ui/parchment-2.png") repeat;
         border-bottom-left-radius: 2px;
         border-bottom-right-radius: 2px;
         &>div {
@@ -1273,7 +1273,7 @@
       border-bottom: none;
       margin: 0 0 4px;
       padding: 4px;
-      background: linear-gradient(rgba(255, 255, 255, 0.3) 100%, rgba(255, 255, 255, 0.3) 100%), url(/systems/D35E/icons/ui/parchment-2.png) repeat;
+      background: linear-gradient(rgba(255, 255, 255, 0.3) 100%, rgba(255, 255, 255, 0.3) 100%), url("icons/ui/parchment-2.png") repeat;
       border-radius: 2px;
       .header-details {
         border-left: none!important;
@@ -1346,18 +1346,18 @@
 
       .window-header {
         color: white;
-        background: url(/systems/D35E/icons/ui/background-header.png) repeat;
+        background: url("icons/ui/background-header.png") repeat;
         border-bottom: 2px solid rgba(255,255,255,0.2);
         line-height: 24px;
       }
 
       section.window-content {
 
-        background: url(/systems/D35E/icons/ui/background-window.png) repeat;
+        background: url("icons/ui/background-window.png") repeat;
       }
 
       section.sheet-content {
-        background: url(/systems/D35E/icons/ui/parchment-2.png) repeat;
+        background: url("icons/ui/parchment-2.png") repeat;
         margin: 0px;
         border-radius: 2px;
         min-height: 420px;
@@ -1373,7 +1373,7 @@
       .original-weapon-box {
         margin-bottom: 4px;
         border-radius: 2px;
-        background: url(/systems/D35E/icons/ui/parchment-2.png) repeat;
+        background: url("icons/ui/parchment-2.png") repeat;
         .sheet-header-small {
           img {
             border: none
@@ -1381,7 +1381,7 @@
 
           &::after{
             content: '';
-            background: url(/systems/D35E/icons/ui/item-frame.png);
+            background: url("icons/ui/item-frame.png");
             background-size: contain;
             width: 40px;
             height: 40px;
@@ -1397,7 +1397,7 @@
         overflow: auto;
       }
       header {
-        background: linear-gradient(rgba(255, 255, 255, 0.3) 100%, rgba(255, 255, 255, 0.3) 100%), url(/systems/D35E/icons/ui/parchment-2.png) repeat;
+        background: linear-gradient(rgba(255, 255, 255, 0.3) 100%, rgba(255, 255, 255, 0.3) 100%), url("icons/ui/parchment-2.png") repeat;
         padding: 4px;
         border-radius: 2px;
       }
@@ -1417,7 +1417,7 @@
   .level-up-data {
     .window-header {
 
-      background: url(/systems/D35E/icons/background/paper.png), url(ui/parchment.jpg) repeat;
+      background: url("icons/background/paper.png"), url("ui/parchment.jpg") repeat;
       background-size: auto;
       background-position-y: -70px;
       background-repeat: no-repeat, repeat;
@@ -1425,7 +1425,7 @@
       border-bottom: 1px solid rgba(0, 0, 0, 0.2);
     }
     .header {
-      background: url(/systems/D35E/icons/background/paper.png), url(ui/parchment.jpg) repeat;
+      background: url("icons/background/paper.png"), url("ui/parchment.jpg") repeat;
       background-repeat: no-repeat, repeat;
       background-position-y: bottom;
     }
@@ -1478,13 +1478,13 @@
   }
 
   .scrolling-header {
-    background: url(/systems/D35E/icons/ui/parchment-2.png) repeat !important;
+    background: url("icons/ui/parchment-2.png") repeat !important;
   }
 
   .item-add-overlay {
 
     .item-add-list {
-      background: url(/systems/D35E/icons/ui/parchment-2.png) repeat !important;
+      background: url("icons/ui/parchment-2.png") repeat !important;
       .item-search-input {
         padding: 10px 10px 10px 35px;
         width: 100%;
@@ -1500,7 +1500,7 @@
 
 
       .item-add-close-box {
-        background: url(/systems/D35E/icons/ui/parchment-2.png) repeat !important;
+        background: url("icons/ui/parchment-2.png") repeat !important;
 
         color: #2C606D;
       }
@@ -1523,7 +1523,7 @@
       padding: 0;
       border-radius: 2px;
       border: none !important;
-      background: url(/systems/D35E/icons/ui/parchment-2.png) repeat;
+      background: url("icons/ui/parchment-2.png") repeat;
 
       input[type="text"],
       textarea {
@@ -1603,7 +1603,7 @@
     header {
       border: 8px solid red;
       /* border-right: none; */
-      border-image: url(/systems/D35E/icons/ui/side-panel.png);
+      border-image: url("icons/ui/side-panel.png");
       padding-right: 0;
       background-size: 100% 100%;
       /* border: 8px solid #55493B; */
@@ -1625,7 +1625,7 @@
       .directory-item {
       align-items: center;
       border-bottom: none;
-      background-image: url(/systems/D35E/icons/ui/basic-bar.png);
+      background-image: url("icons/ui/basic-bar.png");
       background-size: 100% 100%;
       img {
         margin: 4px;
@@ -1638,7 +1638,7 @@
   #token-action-hud {
     button {
       border-radius: 0;
-      background: url(/systems/D35E/icons/ui/name-frame.png);
+      background: url("icons/ui/name-frame.png");
       background-size: 100% 100%;
       border: 1px solid rgba(0, 0, 0, 0);
       padding: 0 5px;
@@ -1662,7 +1662,7 @@
 
 .onboarding {
 
-  background: url(/systems/D35E/icons/ui/onboarding.png);
+  background: url("icons/ui/onboarding.png");
   background-size: 100% 100%;
   height: auto !important;
 
@@ -1686,7 +1686,7 @@
       flex: 0;
       width: 150px;
       height: 150px;
-      background-image: url(/systems/D35E/icons/ui/onboarding-hero.png);
+      background-image: url("icons/ui/onboarding-hero.png");
       background-size: cover;
       position: absolute;
       left: -160px;

--- a/less/token-actions.less
+++ b/less/token-actions.less
@@ -48,7 +48,7 @@
 
     .barbox {
 
-      background-image: url(/systems/D35E/icons/ui/portrait-bar.png);
+      background-image: url("icons/ui/portrait-bar.png");
       background-size: cover;
       width: 240px;
       height: 26px;
@@ -68,7 +68,7 @@
 
       .damagebar {
 
-        background-image: url(/systems/D35E/icons/ui/hp-frame.png);
+        background-image: url("icons/ui/hp-frame.png");
         background-size: cover;
         background-position: right;
         position: absolute;
@@ -87,7 +87,7 @@
       }
 
       .damage {
-        background-image: url(/systems/D35E/icons/ui/hp-bar.png);
+        background-image: url("icons/ui/hp-bar.png");
         background-size: cover;
         background-position: right;
         position: absolute;
@@ -142,7 +142,7 @@
     .overlay {
       width: 100px;
       height: 100px;
-      background-image: url(/systems/D35E/icons/ui/Hero_icon_frame.png);
+      background-image: url("icons/ui/Hero_icon_frame.png");
       background-size: cover;
       position: absolute;
       top: 0px
@@ -162,7 +162,7 @@
           height: 16px;
           width: 16px;
           margin: 0;
-          background-image: url(/systems/D35E/icons/ui/frame-sq-small.png);
+          background-image: url("icons/ui/frame-sq-small.png");
           background-size: cover;
         }
       }

--- a/module/misc/chat-attack.js
+++ b/module/misc/chat-attack.js
@@ -113,7 +113,7 @@ export class ChatAttack {
 
     getShortToolTip(damageText) {
         var match = damageText.match(/([0-9]+) \((.*?)\)/)
-        if (match === null) return `<img src="/systems/D35E/icons/damage-type/unknown.svg" title="Part" class="dmg-type-icon" />${damageText}`
+        if (match === null) return `<img src="systems/D35E/icons/damage-type/unknown.svg" title="Part" class="dmg-type-icon" />${damageText}`
         let dmgVal = match[1];
         let dmgName = match[2];
         let dmgIconBase = match[2].toLowerCase();
@@ -159,7 +159,7 @@ export class ChatAttack {
                 dmgIcon = "unarmed";
                 break;
         }
-        return `<img src="/systems/D35E/icons/damage-type/${dmgIcon}.svg" title="${dmgName}" class="dmg-type-icon" />${dmgVal}`
+        return `<img src="systems/D35E/icons/damage-type/${dmgIcon}.svg" title="${dmgName}" class="dmg-type-icon" />${dmgVal}`
     }
 
     async addDamage({extraParts = [], primaryAttack = true, critical = false, multiattack = 0} = {}) {

--- a/templates/chat/attack-roll-full.html
+++ b/templates/chat/attack-roll-full.html
@@ -114,8 +114,8 @@
             {{#each atk.special as |card|}}
             <button class="{{#if card.isTargeted}}special-action-button{{/if}}" data-action="{{card.action}}" data-json="{{card.data}}" data-value="{{card.value}}">{{#if
                 card.hasImg}}<img src="{{card.img}}">{{/if}}{{#if card.isTargeted}}<img class="target"
-                                                                                        src="/systems/D35E/icons/actions/reticule.svg">{{/if}}{{#unless
-                card.isTargeted}}<img class="target" src="/systems/D35E/icons/actions/impact-point.svg">{{/unless}}{{card.label}}
+                                                                                        src="systems/D35E/icons/actions/reticule.svg">{{/if}}{{#unless
+                card.isTargeted}}<img class="target" src="systems/D35E/icons/actions/impact-point.svg">{{/unless}}{{card.label}}
             </button>
             {{/each}}
         </div>

--- a/templates/chat/attack-roll.html
+++ b/templates/chat/attack-roll.html
@@ -151,8 +151,8 @@
             {{#each atk.special as |card|}}
             <button class="{{#if card.isTargeted}}special-action-button{{/if}}" data-action="{{card.action}}" data-json="{{card.data}}" data-value="{{card.value}}">{{#if
                 card.hasImg}}<img src="{{card.img}}">{{/if}}{{#if card.isTargeted}}<img class="target"
-                                                                                        src="/systems/D35E/icons/actions/reticule.svg">{{/if}}{{#unless
-                card.isTargeted}}<img class="target" src="/systems/D35E/icons/actions/impact-point.svg">{{/unless}}{{card.label}}
+                                                                                        src="systems/D35E/icons/actions/reticule.svg">{{/if}}{{#unless
+                card.isTargeted}}<img class="target" src="systems/D35E/icons/actions/impact-point.svg">{{/unless}}{{card.label}}
             </button>
             {{/each}}
         </div>

--- a/templates/chat/fastheal-roll.html
+++ b/templates/chat/fastheal-roll.html
@@ -10,8 +10,8 @@
         {{#each actions as |card|}}
         <button class="{{#if card.isTargeted}}special-action-button{{/if}}" data-action="{{card.action}}" data-json="{{card.data}}" data-value="{{card.value}}">{{#if
             card.hasImg}}<img src="{{card.img}}">{{/if}}{{#if card.isTargeted}}<img class="target"
-                                                                                    src="/systems/D35E/icons/actions/reticule.svg">{{/if}}{{#unless
-            card.isTargeted}}<img class="target" src="/systems/D35E/icons/actions/impact-point.svg">{{/unless}}{{card.label}}
+                                                                                    src="systems/D35E/icons/actions/reticule.svg">{{/if}}{{#unless
+            card.isTargeted}}<img class="target" src="systems/D35E/icons/actions/impact-point.svg">{{/unless}}{{card.label}}
         </button>
         {{/each}}
     </div>

--- a/templates/onboarding.html
+++ b/templates/onboarding.html
@@ -66,7 +66,7 @@
             </div>
             <div id="onboarding-character-attacks" style="display: none">
                 <p>First, open <strong>Weapon Details</strong> window (again, using <i class="fas fa-edit"></i> button located in the line with Weapon name - in ths case a <strong>Dagger</strong>). After you have opened it, use <strong>Create Attack</strong> button to create an Attack.</p>
-                <p>Afterwards, close Weapon Details Window and navigate to <strong>Summary</strong> tab. You should see <strong>Dagger</strong> in the <strong>Attacks</strong> list with <img src="/systems/D35E/icons/actions/gladius.svg"> icon besides it. Click on the <img src="/systems/D35E/icons/actions/gladius.svg"> icon to attack! In the window that appears, click Single Attack to make a roll and display it in chat.</p>
+                <p>Afterwards, close Weapon Details Window and navigate to <strong>Summary</strong> tab. You should see <strong>Dagger</strong> in the <strong>Attacks</strong> list with <img src="systems/D35E/icons/actions/gladius.svg"> icon besides it. Click on the <img src="systems/D35E/icons/actions/gladius.svg"> icon to attack! In the window that appears, click Single Attack to make a roll and display it in chat.</p>
                 <p style="color: #ff5b41; font-size: 11px">Keep you character sheet open to proceed!</p>
                 <a class="navlink" onclick="showHotbarTutorial()"><i class="fas fa-chevron-right"></i> Great! Let enemies feel my wrath!</a>
                 <p class="tip"><em>Tip!</em> Weapons and other non-character things in Foundry - like Feats, Classes, Attacks, Spells etc. are <strong>Items</strong> - and each Item Details Window look similar. You can read more in Documentation.</p>


### PR DESCRIPTION
Remove hardcoded images in less, js, and html files to support for the routePrefix setting of foundry.

It works on my end with cache disabled. I didn't find any other missing image in the network dev tab while going though some characters and monsters.

Should fix #293.