### PR TITLE
Flurry of Blows

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -957,6 +957,7 @@
   "D35E.Welcome": "Welcome",
   "D35E.Changelog": "Changelog",
   "D35E.FeatRapidShot": "Rapid Shot",
+  "D35E.FeatFlurryOfBlows": "Flurry of Blows",
   "D35E.BagOfHoldingLike": "Works like Bag of Holding (Weightless)",
   "D35E.LightItemLight": "Light",
   "D35E.LightEmitLight": "Item emits light",

--- a/lang/es.json
+++ b/lang/es.json
@@ -893,6 +893,7 @@
   "D35E.Welcome": "Bienvenido",
   "D35E.Changelog": "Registro de cambios",
   "D35E.FeatRapidShot": "Disparo rápido",
+  "D35E.FeatFlurryOfBlows": "Ráfaga de golpes",
   "D35E.BagOfHoldingLike": "Funciona como Bolsa de almacenamiento (sin peso)",
   "D35E.LightItemLight": "Luz",
   "D35E.LightEmitLight": "El artículo emite luz",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -956,6 +956,7 @@
   "D35E.Welcome": "Bienvenue",
   "D35E.Changelog": "Notes de mise à jour",
   "D35E.FeatRapidShot": "Tir rapide",
+  "D35E.FeatFlurryOfBlows": "Déluge de Coups",
   "D35E.BagOfHoldingLike": "Fonctionne comme un sac sans fond (sans poids)",
   "D35E.LightItemLight": "Léger",
   "D35E.LightEmitLight": "L'objet émet une faible lueur",

--- a/module/item/entity.js
+++ b/module/item/entity.js
@@ -1137,6 +1137,7 @@ export class ItemPF extends Item {
                 useAmmoNote = "",
                 useAmmoName = "",
                 rapidShot = false,
+                flurryOfBlows = false,
                 manyshot = false,
                 nonLethal = false,
                 manyshotCount = 0,
@@ -1270,6 +1271,9 @@ export class ItemPF extends Item {
                 if (form.find('[name="rapid-shot"]').prop("checked")) {
                     rapidShot = true;
                 }
+                if (form.find('[name="flurry-of-blows"]').prop("checked")) {
+                    flurryOfBlows = true;
+                }
                 // Primary Attack (for natural attacks)
                 let html = form.find('[name="primary-attack"]');
                 if (typeof html.prop("checked") === "boolean") {
@@ -1374,6 +1378,31 @@ export class ItemPF extends Item {
                 })
                 rollData.rapidShotPenalty = -2;
                 attackExtraParts.push("@rapidShotPenalty");
+            }
+
+            if (flurryOfBlows) {
+                allAttacks.push({
+                    bonus: 0,
+                    label: `Flurry of Blows`
+                })
+                let monkClass = (this.actor?.items || []).filter(o => o.type === "class" && o.name === "Monk")[0];
+                //1-4 = -2
+                if(monkClass.data.data.levels < 5) {
+                    rollData.flurryOfBlowsPenalty = -2;
+                    attackExtraParts.push("@flurryOfBlowsPenalty");
+                }
+                //5-8 = -1
+                else if(monkClass.data.data.levels < 9) {
+                    rollData.flurryOfBlowsPenalty = -1;
+                    attackExtraParts.push("@flurryOfBlowsPenalty");
+                //9+ = 0
+                //11+ = 2nd extra attack
+                } else if(monkClass.data.data.levels > 10) {
+                    allAttacks.push({
+                        bonus: 0,
+                        label: `Flurry of Blows 2`
+                    })
+                }
             }
 
             let isHasted = (this.actor?.items || []).filter(o => o.type === "buff" && o.data.data.active && (o.name === "Haste" || o.data.data.changeFlags.hasted)).length > 0;
@@ -1746,6 +1775,7 @@ export class ItemPF extends Item {
             maxManyshotValue: 2 + Math.floor((getProperty(actor.data, "data.attributes.bab.total") - 6) / 5),
             canGreaterManyshot: actor.items.filter(o => o.type === "feat" && o.name === "Greater Manyshot").length > 0,
             canRapidShot: actor.items.filter(o => o.type === "feat" && o.name === "Rapid Shot").length > 0,
+            canFlurryOfBlows: actor.items.filter(o => o.type === "feat" && o.name === "Flurry of Blows").length > 0,
             maxGreaterManyshotValue: getProperty(actor.data, "data.abilities.wis.mod"),
             weaponFeats: actor.items.filter(o => (o.type === "feat" || (o.type ==="buff" && o.data.data.active)) && o.hasCombatChange(this.type,rollData)),
             weaponFeatsOptional: actor.items.filter(o => (o.type === "feat" || (o.type ==="buff" && o.data.data.active)) && o.hasCombatChange(`${this.type}Optional`,rollData)),

--- a/templates/apps/attack-roll-dialog.html
+++ b/templates/apps/attack-roll-dialog.html
@@ -101,6 +101,16 @@
                onchange="this.nextElementSibling.value=this.value">
         <input type="text" class="auto-save" name="power-attack" value="0" disabled style="flex: 0 30; margin-left: 8px"/>
         {{/if}}
+        
+        {{#if canFlurryOfBlows}}
+        <div class="form-group">
+            <label>{{localize "D35E.FeatFlurryOfBlows"}}</label>
+            <label class="checkbox" style="flex: 0 16px; margin-right: 8px; position: relative">
+                <input type="checkbox" class="stylized" data-feat="flurry-of-blows" name="flurry-of-blows"/>
+                <span class="checkmark"></span>
+            </label>
+        </div>
+        {{/if}}
     </div>
     {{/unless}}
 
@@ -338,7 +348,7 @@
                     if (isGreaterManyshot)
                         baseExtraAttacks = baseExtraAttacks * greaterManyshotCount;
                 }
-                console.log('Attacks', baseExtraAttacks, isRapidShot)
+                console.log('Attacks', baseExtraAttacks, isRapidShot, isFlurryOfBlows)
                 $('option:selected', select).closest("section").find("input[name='ammo-dmg-formula']").val(damage)
                 $('option:selected', select).closest("section").find("input[name='ammo-dmg-type']").val(type)
                 $('option:selected', select).closest("section").find("input[name='ammo-attack']").val(attack)


### PR DESCRIPTION
Implementation of the monk's Flurry of Blows feature.
Like rapid shot, it allows an extra attack with all attacks at -2.
Unlike rapid shot though, it changes with the monk's level. At 5, the penalty is reduced to -1, at 9, there's no penalty, and at 11, there's a second extra attack.
The only thing I'm not sure about it
"let monkClass = (this.actor?.items || []).filter(o => o.type === "class" && o.name === "Monk")[0];"
You can only see the checkbox if you have Flurry of Blows, but I can see it causing problems if "Flurry of Blows" is put in a custom class. Then, "Monk" won't be found and it'll probably cause an error. Not sure what to do about that, maybe default to "total character level" if Monk is not found? Or leave it in it's "level 1 state"